### PR TITLE
Use some list comprehensions, fall back from multi-chunk encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Place the WARC files you would to explore with WARC-GPT under `./warc` and run t
 poetry run flask ingest
 
 # May help with performance in certain cases: only ingest 1 chunk of text at a time.
-poetry run flask ingest --no-multi-chunk-mode
+poetry run flask ingest --batch-size 1
 ```
 
 **Note:** Running `ingest` clears the `./chromadb` folder.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Place the WARC files you would to explore with WARC-GPT under `./warc` and run t
 
 ```bash
 poetry run flask ingest
+
+# May help with performance in certain cases: only ingest 1 chunk of text at a time.
+poetry run flask ingest --no-multi-chunk-mode
 ```
 
 **Note:** Running `ingest` clears the `./chromadb` folder.

--- a/warc_gpt/commands/ingest.py
+++ b/warc_gpt/commands/ingest.py
@@ -195,7 +195,14 @@ def ingest(multi_chunk_mode) -> None:
                 text_chunks = [chunk_prefix + chunk for chunk in text_chunks]
 
                 # Generate embeddings and metadata for each chunk
-                documents, ids, metadatas, embeddings, encoding_timings = chunk_objects(
+                (
+                    documents,
+                    ids,
+                    metadatas,
+                    embeddings,
+                    multi_chunk_mode,
+                    encoding_timings
+                ) = chunk_objects(
                     record_data,
                     text_chunks,
                     embedding_model,
@@ -223,7 +230,8 @@ def chunk_objects(
     encoding_timings: list[float],
 ):
     """
-    Return one document, metadata, id, and embedding object per chunk
+    Return one document, metadata, id, and embedding object per chunk; also return
+    control variables multi_chunk_mode and encoding_timings
 
     """
     environ = os.environ
@@ -237,7 +245,7 @@ def chunk_objects(
     ids = [f"{record_data['warc_record_id']}-{i+1}" for i in chunk_range]
 
     metadatas = [
-        dict(record_data, **{"warc_record_text": text_chunks[i][len(chunk_prefix) :]})
+        dict(record_data, **{"warc_record_text": text_chunks[i][len(chunk_prefix):]})
         for i in chunk_range
     ]
 
@@ -270,4 +278,4 @@ def chunk_objects(
             for chunk in text_chunks
         ]
 
-    return documents, ids, metadatas, embeddings, encoding_timings
+    return documents, ids, metadatas, embeddings, multi_chunk_mode, encoding_timings

--- a/warc_gpt/commands/ingest.py
+++ b/warc_gpt/commands/ingest.py
@@ -24,8 +24,12 @@ from warc_gpt import WARC_RECORD_DATA
 
 
 @current_app.cli.command("ingest")
-@click.option("--multi-chunk-mode/--no-multi-chunk-mode", default=True,
-              help="Encode multiple chunks at once", show_default=True)
+@click.option(
+    "--multi-chunk-mode/--no-multi-chunk-mode",
+    default=True,
+    help="Encode multiple chunks at once",
+    show_default=True,
+)
 def ingest(multi_chunk_mode) -> None:
     """
     Generates sentence embeddings and metadata for a set of WARCs and saves them in a vector store.
@@ -192,7 +196,11 @@ def ingest(multi_chunk_mode) -> None:
 
                 # Generate embeddings and metadata for each chunk
                 documents, ids, metadatas, embeddings, encoding_timings = chunk_objects(
-                    record_data, text_chunks, embedding_model, multi_chunk_mode, encoding_timings
+                    record_data,
+                    text_chunks,
+                    embedding_model,
+                    multi_chunk_mode,
+                    encoding_timings,
                 )
                 total_embeddings += len(embeddings)
 
@@ -207,9 +215,13 @@ def ingest(multi_chunk_mode) -> None:
     click.echo(f"Total: {total_embeddings} embeddings from {total_records} HTML/PDF records.")
 
 
-def chunk_objects(record_data: dict, text_chunks: list[str],
-                  embedding_model: SentenceTransformer,
-                  multi_chunk_mode: bool, encoding_timings: list[float]):
+def chunk_objects(
+    record_data: dict,
+    text_chunks: list[str],
+    embedding_model: SentenceTransformer,
+    multi_chunk_mode: bool,
+    encoding_timings: list[float],
+):
     """
     Return one document, metadata, id, and embedding object per chunk
 
@@ -225,10 +237,8 @@ def chunk_objects(record_data: dict, text_chunks: list[str],
     ids = [f"{record_data['warc_record_id']}-{i+1}" for i in chunk_range]
 
     metadatas = [
-        dict(
-            record_data,
-            **{"warc_record_text": text_chunks[i][len(chunk_prefix):]}
-        ) for i in chunk_range
+        dict(record_data, **{"warc_record_text": text_chunks[i][len(chunk_prefix) :]})
+        for i in chunk_range
     ]
 
     # In some contexts, passing all the text chunks to embedding_model.encode() at once
@@ -249,7 +259,7 @@ def chunk_objects(record_data: dict, text_chunks: list[str],
                 pass
             elif encoding_time > len(text_chunks) * mean(encoding_timings):
                 multi_chunk_mode = False
-                click.echo('Leaving multi-chunk mode')
+                click.echo("Leaving multi-chunk mode")
     else:
         # we've left multi-chunk mode, and there's no need to capture timings anymore
         embeddings = [

--- a/warc_gpt/views/api/complete.py
+++ b/warc_gpt/views/api/complete.py
@@ -24,7 +24,7 @@ def post_complete():
     - "temperature": Defaults to 0.0
     - "search_results": Output from /api/search. List of WARC_RECORD_DATA entries.
     - "max_tokens": If provided, caps number of tokens that will be generated in response.
-    - "history": A list of chat completion objects representing the chat history. Each object must contain "user" and "content".
+    - "history": A list of chat completion objects representing the chat history. Each object must contain "user" and "content".  # noqa
 
     Example of a "history" list:
     ```


### PR DESCRIPTION
For your delectation, but not necessarily for inclusion -- this change populates `documents`, `ids`, and `embeddings` with list comprehensions rather than in a loop. (When I tried forming `metadatas` this way, it didn't work, though I think it could be made to.) In my limited experiments, this is somewhat more than 3x faster than before, but I bet that could depend on `VECTOR_SEARCH_SENTENCE_TRANSFORMER_MODEL` (`"BAAI/bge-m3"` in this case).

~Because the original code was super slow with `BAAI/bge-m3` on 5-chunk pages, I also made the change to give one chunk at a time to `embedding_model.encode()` -- this may not be a good idea for other embedding models or other hardware setups.~ (Now see the comment below about multi-chunk mode.)

I'm not making any real claims about the performance of list comprehensions here, btw. I started making these changes for aesthetic reasons -- I think they look nice.