### PR TITLE
First cut at tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ test.py
 TODO.md
 runs/
 _*/
+
+tests/visualizations/
+tests/chromadb/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1330,6 +1330,17 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["jaraco.collections", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.1.2"
 description = "Safely pass data to untrusted environments and back."
@@ -2692,6 +2703,21 @@ packaging = "*"
 tenacity = ">=6.2.0"
 
 [[package]]
+name = "pluggy"
+version = "1.4.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
+    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "posthog"
 version = "3.5.0"
 description = "Integrate PostHog into any python application."
@@ -3013,6 +3039,41 @@ files = [
     {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
     {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
 ]
+
+[[package]]
+name = "pytest"
+version = "8.1.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"},
+    {file = "pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.4,<2.0"
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+description = "A py.test plugin that parses environment files before running tests"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732"},
+    {file = "pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f"},
+]
+
+[package.dependencies]
+pytest = ">=5.0.0"
+python-dotenv = ">=0.9.1"
 
 [[package]]
 name = "python-dateutil"
@@ -4598,4 +4659,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "d2b60459cc282f93cfb4209078497dfb2b1ddfc9f71ee72cdcb6a3ea86a98485"
+content-hash = "79f6616efdf3fa622265d9071b8b700d4fa65dbf2d8c67ec3c40d018ecd93af8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ warcio = "^1.7.4"
 [tool.poetry.group.dev.dependencies]
 black = "^24.3.0"
 flake8 = "^6.1.0"
+pytest = "^8.1.1"
+pytest-dotenv = "^0.5.2"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"
@@ -39,3 +41,9 @@ requires = ["poetry-core"]
 
 [tool.black]
 line-length = 100
+
+[tool.pytest.ini_options]
+env_override_existing_values = 1
+env_files = [
+    "tests/.test.env"
+]

--- a/tests/.test.env
+++ b/tests/.test.env
@@ -1,0 +1,100 @@
+#-------------------------------------------------------------------------------
+# LLM APIs settings 
+#-------------------------------------------------------------------------------
+# NOTE: 
+# - WARC-GPT can use both OpenAI and Ollama at the same time, but needs at least one of the two.
+# - Ollama is one of the simplest ways to get started running models locally: https://ollama.ai/
+OLLAMA_API_URL="http://localhost:11434"
+
+#OPENAI_API_KEY="" 
+#OPENAI_ORG_ID=""
+
+# NOTE: 
+# OPENAI_BASE_URL can be used to interact with OpenAI-compatible providers.
+# For example:
+# - https://huggingface.co/blog/tgi-messages-api
+# - https://docs.vllm.ai/en/latest/getting_started/quickstart.html#using-openai-completions-api-with-vllm
+# 
+# Important:
+# - Make sure to specify both OPENAI_BASE_URL and OPENAI_COMPATIBLE_MODEL when doing so.
+# - These two values do not need to be set when using OpenAI as a provider.
+#OPENAI_BASE_URL=""
+#OPENAI_COMPATIBLE_MODEL=""
+
+#-------------------------------------------------------------------------------
+# Text Completion Prompts
+#-------------------------------------------------------------------------------
+# NOTE: {history} {rag} and {request} are reserved keywords.
+TEXT_COMPLETION_BASE_PROMPT = "
+{history}
+
+You are a helpful assistant.
+
+{rag}
+
+Request: {request}
+
+Helpful response (plain text, no markdown): 
+"
+
+# NOTE: Injected into BASE prompt when relevant.
+# Inspired by LangChain's default RAG prompt.
+# {context} is a reserved keyword.
+TEXT_COMPLETION_RAG_PROMPT = "
+Here is context to help you fulfill the user's request:
+{context}
+----------------
+Context comes from web pages that were captured as part of a web archives collection. 
+When possible, use context to answer the question asked by the user.
+If you don't know the answer, just say that you don't know, don't try to make up an answer. 
+Ignore context if it is empty or irrelevant.
+Cite and quote your sources whenever possible. Use their number (for example: [1]) and / or URL to reference them.
+
+"
+
+# NOTE: Injected into BASE prompt when relevant.
+# NOTE: {history} is a reserved keyword
+TEXT_COMPLETION_HISTORY_PROMPT = "
+Here is a summary of the conversation thus far:
+{history}
+----------------
+
+"
+
+#-------------------------------------------------------------------------------
+# Paths
+#-------------------------------------------------------------------------------
+WARC_FOLDER_PATH="./tests/warc"
+VISUALIZATIONS_FOLDER_PATH="./tests/visualizations"
+VECTOR_SEARCH_PATH="./tests/chromadb"
+
+#-------------------------------------------------------------------------------
+# Vector Store / Search settings
+#-------------------------------------------------------------------------------
+VECTOR_SEARCH_COLLECTION_NAME="collection"
+
+VECTOR_SEARCH_SENTENCE_TRANSFORMER_MODEL="intfloat/e5-large-v2" # Can be any Sentence-Transformers compatible model available on Hugging Face
+VECTOR_SEARCH_SENTENCE_TRANSFORMER_DEVICE="cpu" # "mps" or "cuda" might help with performance, depending on available hardware. See: https://www.sbert.net/examples/applications/computing-embeddings/README.html#sentence_transformers.SentenceTransformer
+VECTOR_SEARCH_DISTANCE_FUNCTION="cosine" # https://docs.trychroma.com/usage-guide#changing-the-distance-function
+VECTOR_SEARCH_NORMALIZE_EMBEDDINGS="true"
+VECTOR_SEARCH_CHUNK_PREFIX="passage: " # Can be used to add prefix to text embeddings stored in vector store
+VECTOR_SEARCH_QUERY_PREFIX="query: " # Can be used to add prefix to text embeddings used for semantic search
+
+VECTOR_SEARCH_TEXT_SPLITTER_CHUNK_OVERLAP=25 # Determines, for a given chunk of text, how many tokens must overlap with adjacent chunks.
+VECTOR_SEARCH_SEARCH_N_RESULTS=4 # How many entries should the vector search return?
+
+#-------------------------------------------------------------------------------
+# Basic Rate Limiting
+#-------------------------------------------------------------------------------
+# NOTE:
+# - This set of variables allows for applying rate-limiting to individual API routes. 
+# - See https://flask-limiter.readthedocs.io/en/stable/ for details and syntax.
+RATE_LIMIT_STORAGE_URI="memory://"
+API_MODELS_RATE_LIMIT="1/second"
+API_SEARCH_RATE_LIMIT="120 per 1 hour"
+API_COMPLETE_RATE_LIMIT="60 per 1 hour"
+
+#-------------------------------------------------------------------------------
+# Hugging Face's tokenizer settings
+#-------------------------------------------------------------------------------
+TOKENIZERS_PARALLELISM="false"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+import pytest
+import tempfile
+import shutil
+from dotenv import find_dotenv, load_dotenv
+from pathlib import Path
+from warc_gpt import create_app
+
+
+@pytest.fixture(scope='session', autouse=True)
+def load_env():
+    env_file = find_dotenv('tests/.test.env')
+    load_dotenv(env_file)
+
+
+@pytest.fixture()
+def app():
+    clean_test_directories()
+
+    # move existing .env, if present; this is not the right way to
+    # do this, I think
+    dotenv = Path(".") / ".env"
+    tempdir = Path(tempfile.mkdtemp())
+    tempdotenv = tempdir / ".env"
+    if dotenv.is_file():
+        dotenv.rename(tempdotenv)
+
+    app = create_app()
+
+    yield app
+
+    # clean up / reset resources here
+    clean_test_directories()
+
+    # replace existing .env
+    if tempdotenv.is_file():
+        tempdotenv.rename(dotenv)
+    tempdir.rmdir()
+        
+
+@pytest.fixture()
+def runner(app):
+    return app.test_cli_runner()
+
+
+def clean_test_directories():
+    for dir in ["chromadb", "visualizations"]:
+        d = Path(".") / "tests" / "dir"
+        if d.is_dir():
+            shutil.rmtree(d)
+    

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+import pytest
+import os
+from pathlib import Path
+
+
+def test_ingest(runner):
+    db = Path(os.environ["VECTOR_SEARCH_PATH"]) / "chroma.sqlite3"
+    collections = Path(os.environ["VISUALIZATIONS_FOLDER_PATH"]) / "collection.html"
+
+    assert os.environ["VISUALIZATIONS_FOLDER_PATH"] == "./tests/visualizations"
+    
+    os.environ["WARC_FOLDER_PATH"] = "./tests/no_such_folder"
+    result = runner.invoke(args="ingest")
+    assert result.exit_code == 1
+    assert "No WARC files to ingest." in result.output
+    assert not db.is_file()
+        
+    os.environ["WARC_FOLDER_PATH"] = "./tests/warc"
+    result = runner.invoke(args="ingest")
+    assert result.exit_code == 0
+    assert "2 WARC files to ingest." in result.output
+    assert db.is_file()
+
+    result = runner.invoke(args="visualize")
+    assert "You may not have enough input data" in result.output
+    assert result.exit_code == 1
+    
+    result = runner.invoke(args=["visualize", "--perplexity", "2"])
+    assert "./tests/visualizations/collection.html saved to disk." in result.output
+    assert result.exit_code == 0
+    assert collections.is_file()

--- a/warc_gpt/commands/visualize.py
+++ b/warc_gpt/commands/visualize.py
@@ -2,6 +2,7 @@
 `commands.visualize` module: Controller for the `visualize` CLI command.
 """
 import os
+import sys
 from textwrap import wrap
 
 import click
@@ -85,7 +86,7 @@ def visualize(questions: str, perplexity: float) -> None:
     except ValueError as e:
         if f'{e}' == "perplexity must be less than n_samples":
             click.echo("You may not have enough input data; add some or reduce perplexity to less than n_samples.")  # noqa
-            return 1
+            sys.exit(1)
         else:
             raise
 


### PR DESCRIPTION
This is a first cut at tests. It only tests the ingest and visualization commands so far, not the web application or the API.

Because I had to move and restore an existing `.env` to get this to work, I think either I have something wrong with test set-up, or there's an infelicity with loading the application's config. TBD.

These tests should eventually exercise all of the application, possibly under different regimes, say, of `VECTOR_SEARCH_SENTENCE_TRANSFORMER_MODEL` and `VECTOR_SEARCH_SENTENCE_TRANSFORMER_DEVICE`. They could also track times for different ingests on specific hardware, and fail or warn when times go over baseline.

I haven't thought much yet about how to handle `OLLAMA_API_URL` in CI. There may not be a way to do that without standing up an external service.