### PR TITLE
Log a warnining and return a 500 if no models found

### DIFF
--- a/warc_gpt/utils/list_available_models.py
+++ b/warc_gpt/utils/list_available_models.py
@@ -45,4 +45,7 @@ def list_available_models() -> list:
             current_app.logger.error("Could not list Ollama models.")
             current_app.logger.debug(traceback.format_exc())
 
+    if not models:
+        current_app.logger.warning("No models found, returning empty list.")
+
     return models

--- a/warc_gpt/views/ui.py
+++ b/warc_gpt/views/ui.py
@@ -25,8 +25,14 @@ def get_root():
                 default_model = model
                 break
 
-    if not default_model:
+    if not default_model and available_models:
         default_model = available_models[0]
+
+    if not default_model:
+        return (
+            "ERROR: No models available. Check your environment configuration in your .env file.",
+            500,
+        )
 
     app_consts = {
         "available_models": available_models,


### PR DESCRIPTION
This should help new users if they haven't configured their environment correctly.

Currently, if Ollama is installed but no models are available, no exception is thrown or logged until here:

https://github.com/harvard-lil/warc-gpt/blob/main/warc_gpt/views/ui.py#L29

```
...
  File "<REDACTED>/warc-gpt/warc_gpt/views/ui.py", line 30, in get_root
    default_model = available_models[0]
                    ^^^^^^^^^^^^^^^^^^^
IndexError: list index out of range
```

Looking at the code, this could also happen if the user has removed all the relevant environment variables from their `.env` file.

The solution is a bit crude, but at least there is a 500 with a message, instead of a naked 500.